### PR TITLE
fix(periph_i2s): allocate single PDM channel for simplex RX/TX

### DIFF
--- a/esp_board_manager/peripherals/periph_i2s/periph_i2s.c
+++ b/esp_board_manager/peripherals/periph_i2s/periph_i2s.c
@@ -109,7 +109,19 @@ int periph_i2s_init(void *cfg, int cfg_size, void **periph_handle)
      * This limitation can be resolved after I2S support full-duplex mode automatically.
      **/
     if (i2s_chan_handles[config->port].chan_out == NULL && i2s_chan_handles[config->port].chan_in == NULL) {
-        err = i2s_new_channel(&chan_cfg, &i2s_chan_handles[config->port].chan_out, &i2s_chan_handles[config->port].chan_in);
+#if CONFIG_SOC_I2S_SUPPORTS_PDM
+        /* PDM simplex: RX-only or TX-only must not allocate the unused direction.
+         * esp_codec_dev treats pair_chan as a live duplex peer; an uninitialized TX
+         * handle breaks open/reconfig and causes i2s_channel_read() timeouts. */
+        if (config->mode == I2S_COMM_MODE_PDM && config->direction == I2S_DIR_RX) {
+            err = i2s_new_channel(&chan_cfg, NULL, &i2s_chan_handles[config->port].chan_in);
+        } else if (config->mode == I2S_COMM_MODE_PDM && config->direction == I2S_DIR_TX) {
+            err = i2s_new_channel(&chan_cfg, &i2s_chan_handles[config->port].chan_out, NULL);
+        } else
+#endif
+        {
+            err = i2s_new_channel(&chan_cfg, &i2s_chan_handles[config->port].chan_out, &i2s_chan_handles[config->port].chan_in);
+        }
     }
     if (config->mode == I2S_COMM_MODE_STD) {
         if (config->direction == I2S_DIR_TX && !i2s_chan_handles[config->port].out_en) {


### PR DESCRIPTION
## Summary

- In `periph_i2s_init()`, when mode is PDM and direction is RX-only or TX-only, call `i2s_new_channel()` with `NULL` for the unused direction instead of always creating both TX and RX handles.
- STD/TDM initialization is unchanged: both channels are still allocated together to satisfy the existing I2S clock constraint (clock is driven by TX).

## Problem

For PDM simplex boards (e.g. PDM microphone RX-only), the driver previously always allocated both `chan_out` and `chan_in` via `i2s_new_channel(&chan_cfg, &chan_out, &chan_in)`.

`esp_codec_dev` treats `pair_chan` as an active duplex peer. An allocated but uninitialized TX handle on an RX-only PDM setup can break open/reconfig and lead to `i2s_channel_read()` timeouts.

## Solution

Under `CONFIG_SOC_I2S_SUPPORTS_PDM`:

| Mode / direction | `i2s_new_channel` TX | RX |
|------------------|----------------------|-----|
| PDM + RX         | `NULL`               | `chan_in` |
| PDM + TX         | `chan_out`           | `NULL` |
| Other (STD/TDM/duplex PDM) | both | both |

This matches PDM simplex hardware while keeping the existing duplex behavior for non-PDM modes documented in the file NOTE block.

## Test plan

- [ ] Build on a SoC with `CONFIG_SOC_I2S_SUPPORTS_PDM` (e.g. ESP32-S3 / C3 / etc.)
- [ ] PDM RX-only: init board with PDM mic, open `esp_codec_dev`, verify record/read without timeout
- [ ] PDM TX-only (if applicable): playback works
- [ ] STD I2S codec (duplex or RX with TX clock): no regression
- [ ] Re-init / deinit same port: no leak or double-free
