### PR TITLE
fix(gpio_expander): return raw expander handle

### DIFF
--- a/esp_board_manager/devices/dev_gpio_expander/dev_gpio_expander.c
+++ b/esp_board_manager/devices/dev_gpio_expander/dev_gpio_expander.c
@@ -51,47 +51,42 @@ int dev_gpio_expander_init(void *cfg, int cfg_size, void **device_handle)
         goto init_err_unref_i2c;
     }
 
-    esp_io_expander_handle_t *dev = (esp_io_expander_handle_t *)calloc(1, sizeof(esp_io_expander_handle_t));
-    if (!dev) {
-        ESP_LOGE(TAG, "Failed to allocate memory for io_expander device");
-        goto init_err_unref_i2c;
-    }
+    esp_io_expander_handle_t dev = NULL;
 
-    ret = io_expander_factory_entry_t(bus_handle, dev_addr, dev);
-    if (ret != ESP_OK || !*dev) {
+    ret = io_expander_factory_entry_t(bus_handle, dev_addr, &dev);
+    if (ret != ESP_OK || !dev) {
         ESP_LOGE(TAG, "Failed to create IO expander handle\n");
-        free(dev);
         goto init_err_unref_i2c;
     }
 
     for (uint32_t i = 0; i < config->max_pins; i++) {
         uint32_t pin_mask = (1 << i);
         if (config->output_io_mask & pin_mask) {
-            ESP_GOTO_ON_ERROR(esp_io_expander_set_dir(*dev, pin_mask, IO_EXPANDER_OUTPUT),
+            ESP_GOTO_ON_ERROR(esp_io_expander_set_dir(dev, pin_mask, IO_EXPANDER_OUTPUT),
                               io_expander_del, TAG, "Set IO expander pin %" PRIu32 " as output failed", i);
             uint8_t level = (config->output_io_level_mask >> i) & 1;
-            ESP_GOTO_ON_ERROR(esp_io_expander_set_level(*dev, pin_mask, level),
+            ESP_GOTO_ON_ERROR(esp_io_expander_set_level(dev, pin_mask, level),
                               io_expander_del, TAG, "Set IO expander pin %" PRIu32 " default level failed", i);
             if (config->enable_mode_set) {
                 esp_io_expander_output_mode_t mode = (esp_io_expander_output_mode_t)((config->output_io_mode_mask >> i) & 1);
-                ESP_GOTO_ON_ERROR(esp_io_expander_set_output_mode(*dev, pin_mask, mode),
+                ESP_GOTO_ON_ERROR(esp_io_expander_set_output_mode(dev, pin_mask, mode),
                                   io_expander_del, TAG, "Set IO expander pin %" PRIu32 " output mode failed", i);
             }
             ESP_LOGI(TAG, "Set IO expander pin %" PRIu32 " as output, level: %d", i, level);
         } else if (config->input_io_mask & pin_mask) {
-            ESP_GOTO_ON_ERROR(esp_io_expander_set_dir(*dev, pin_mask, IO_EXPANDER_INPUT),
+            ESP_GOTO_ON_ERROR(esp_io_expander_set_dir(dev, pin_mask, IO_EXPANDER_INPUT),
                               io_expander_del, TAG, "Set IO expander pin %" PRIu32 " as input failed", i);
             ESP_LOGI(TAG, "Set IO expander pin %" PRIu32 " as input", i);
         }
         if (config->io_pullup_mask & pin_mask) {
             esp_io_expander_pullupdown_t state = IO_EXPANDER_PULL_UP;
-            ESP_GOTO_ON_ERROR(esp_io_expander_set_pullupdown(*dev, pin_mask, state),
+            ESP_GOTO_ON_ERROR(esp_io_expander_set_pullupdown(dev, pin_mask, state),
                               io_expander_del, TAG, "Set IO expander pin %" PRIu32 " pull-up failed", i);
             ESP_LOGI(TAG, "Enable IO expander pin %" PRIu32 " pull-up", i);
         }
         if (config->io_pulldown_mask & pin_mask) {
             esp_io_expander_pullupdown_t state = IO_EXPANDER_PULL_DOWN;
-            ESP_GOTO_ON_ERROR(esp_io_expander_set_pullupdown(*dev, pin_mask, state),
+            ESP_GOTO_ON_ERROR(esp_io_expander_set_pullupdown(dev, pin_mask, state),
                               io_expander_del, TAG, "Set IO expander pin %" PRIu32 " pull-down failed", i);
             ESP_LOGI(TAG, "Enable IO expander pin %" PRIu32 " pull-down", i);
         }
@@ -105,10 +100,9 @@ int dev_gpio_expander_init(void *cfg, int cfg_size, void **device_handle)
     return 0;
 
 io_expander_del:
-    if (*dev) {
-        esp_io_expander_del(*dev);
+    if (dev) {
+        esp_io_expander_del(dev);
     }
-    free(dev);
 init_err_unref_i2c:
     esp_board_periph_unref_handle(config->i2c_name);
     return -1;
@@ -125,15 +119,14 @@ int dev_gpio_expander_deinit(void *device_handle)
         }
     }
 
-    esp_io_expander_handle_t *io_expander_dev = (esp_io_expander_handle_t *)device_handle;
-    if (*io_expander_dev) {
-        esp_io_expander_del(*io_expander_dev);
+    esp_io_expander_handle_t io_expander_dev = (esp_io_expander_handle_t)device_handle;
+    if (io_expander_dev) {
+        esp_io_expander_del(io_expander_dev);
     }
 
     if (cfg) {
         esp_board_periph_unref_handle(cfg->i2c_name);
     }
     ESP_LOGD(TAG, "Successfully deinitialized: %s, dev: %p", cfg ? cfg->name : "(unknown)", io_expander_dev);
-    free(io_expander_dev);
     return 0;
 }

--- a/esp_board_manager/test_apps/main/test_dev_gpio_expander.c
+++ b/esp_board_manager/test_apps/main/test_dev_gpio_expander.c
@@ -6,6 +6,7 @@
  */
 
 #include <inttypes.h>
+#include <stdbool.h>
 #include "esp_check.h"
 #include "esp_io_expander.h"
 #include "esp_log.h"
@@ -19,29 +20,199 @@
 
 static const char *TAG = "TEST_GPIO_EXPANDER";
 
+static esp_err_t restore_test_pin(esp_io_expander_handle_t gpio_expander,
+                                  const dev_io_expander_config_t *gpio_config)
+{
+    if (gpio_config->output_io_mask & GPIO_EXPANDER_TEST) {
+        esp_err_t ret = esp_io_expander_set_dir(
+            gpio_expander,
+            GPIO_EXPANDER_TEST,
+            IO_EXPANDER_OUTPUT
+        );
+        if (ret != ESP_OK) {
+            return ret;
+        }
+
+        const uint8_t level =
+            (gpio_config->output_io_level_mask & GPIO_EXPANDER_TEST) ? 1 : 0;
+
+        return esp_io_expander_set_level(
+            gpio_expander,
+            GPIO_EXPANDER_TEST,
+            level
+        );
+    }
+
+    if (gpio_config->input_io_mask & GPIO_EXPANDER_TEST) {
+        return esp_io_expander_set_dir(
+            gpio_expander,
+            GPIO_EXPANDER_TEST,
+            IO_EXPANDER_INPUT
+        );
+    }
+
+    /*
+     * The test temporarily drives the pin, so if the board configuration does
+     * not assign it a direction, release it as an input before returning.
+     */
+    return esp_io_expander_set_dir(
+        gpio_expander,
+        GPIO_EXPANDER_TEST,
+        IO_EXPANDER_INPUT
+    );
+}
+
+static bool check_operation(const char *operation, esp_err_t ret)
+{
+    if (ret == ESP_OK) {
+        ESP_LOGI(TAG, "%s: OK", operation);
+        return true;
+    }
+
+    ESP_LOGE(
+        TAG,
+        "%s failed: %s (0x%x)",
+        operation,
+        esp_err_to_name(ret),
+        (unsigned)ret
+    );
+    return false;
+}
+
 void test_dev_gpio_expander(void)
 {
     void *dev_cfg = NULL;
-    esp_err_t ret = esp_board_manager_get_device_config(BMGR_TEST_NAME_GPIO_EXPANDER, &dev_cfg);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to get gpio_expander device config: %s", esp_err_to_name(ret));
+    esp_err_t ret = esp_board_manager_get_device_config(
+        BMGR_TEST_NAME_GPIO_EXPANDER,
+        &dev_cfg
+    );
+    if (ret != ESP_OK || dev_cfg == NULL) {
+        ESP_LOGE(
+            TAG,
+            "Failed to get gpio_expander device config: %s",
+            esp_err_to_name(ret)
+        );
         return;
     }
 
     void *dev_handle = NULL;
-    ret = esp_board_manager_get_device_handle(BMGR_TEST_NAME_GPIO_EXPANDER, &dev_handle);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to get gpio_expander device handle: %s", esp_err_to_name(ret));
+    ret = esp_board_manager_get_device_handle(
+        BMGR_TEST_NAME_GPIO_EXPANDER,
+        &dev_handle
+    );
+    if (ret != ESP_OK || dev_handle == NULL) {
+        ESP_LOGE(
+            TAG,
+            "Failed to get gpio_expander device handle: %s",
+            esp_err_to_name(ret)
+        );
         return;
     }
 
-    dev_io_expander_config_t *gpio_config = (dev_io_expander_config_t *)dev_cfg;
-    esp_io_expander_handle_t *gpio_expander = (esp_io_expander_handle_t *)dev_handle;
+    dev_io_expander_config_t *gpio_config =
+        (dev_io_expander_config_t *)dev_cfg;
+
+    /*
+     * gpio_expander publishes the actual esp_io_expander_handle_t.
+     * This direct cast is the public handle contract under test.
+     */
+    esp_io_expander_handle_t gpio_expander =
+        (esp_io_expander_handle_t)dev_handle;
 
     ESP_LOGI(TAG, "GPIO Expander Device Config:");
     ESP_LOGI(TAG, "  Name: %s", gpio_config->name);
-    esp_io_expander_print_state(*gpio_expander);
-    ESP_LOGI(TAG, " GPIO Expander Device test completed successfully!");
+    ESP_LOGI(TAG, "  Handle: %p", gpio_expander);
 
-    return;
+    /*
+     * The original test dereferenced dev_handle as an
+     * esp_io_expander_handle_t *, which masked an extra-indirection bug in the
+     * gpio_expander adapter. Exercise the public handle directly so that such a
+     * regression fails in the test instead of application code.
+     */
+    if (!check_operation(
+            "print initial state",
+            esp_io_expander_print_state(gpio_expander))) {
+        return;
+    }
+
+    bool pin_modified = false;
+
+    ret = esp_io_expander_set_dir(
+        gpio_expander,
+        GPIO_EXPANDER_TEST,
+        IO_EXPANDER_OUTPUT
+    );
+    if (!check_operation("set test pin OUTPUT", ret)) {
+        goto restore;
+    }
+    pin_modified = true;
+
+    ret = esp_io_expander_set_level(
+        gpio_expander,
+        GPIO_EXPANDER_TEST,
+        0
+    );
+    if (!check_operation("set test pin LOW", ret)) {
+        goto restore;
+    }
+
+    ret = esp_io_expander_set_level(
+        gpio_expander,
+        GPIO_EXPANDER_TEST,
+        1
+    );
+    if (!check_operation("set test pin HIGH", ret)) {
+        goto restore;
+    }
+
+    ret = esp_io_expander_set_dir(
+        gpio_expander,
+        GPIO_EXPANDER_TEST,
+        IO_EXPANDER_INPUT
+    );
+    if (!check_operation("set test pin INPUT", ret)) {
+        goto restore;
+    }
+
+    uint32_t level_mask = 0;
+    ret = esp_io_expander_get_level(
+        gpio_expander,
+        GPIO_EXPANDER_TEST,
+        &level_mask
+    );
+    if (!check_operation("read test pin", ret)) {
+        goto restore;
+    }
+
+    /*
+     * Validate the API/driver operation, not a specific physical voltage.
+     * External circuitry may legitimately determine the input level.
+     */
+    ESP_LOGI(
+        TAG,
+        "Test pin physical level: %s",
+        (level_mask & GPIO_EXPANDER_TEST) ? "HIGH" : "LOW"
+    );
+
+restore:
+    if (pin_modified) {
+        const esp_err_t restore_ret =
+            restore_test_pin(gpio_expander, gpio_config);
+
+        if (!check_operation("restore test pin", restore_ret)) {
+            return;
+        }
+    }
+
+    if (ret != ESP_OK) {
+        return;
+    }
+
+    if (!check_operation(
+            "print final state",
+            esp_io_expander_print_state(gpio_expander))) {
+        return;
+    }
+
+    ESP_LOGI(TAG, "GPIO Expander Device test completed successfully!");
 }


### PR DESCRIPTION
Description

Fix gpio_expander publishing an extra level of pointer indirection as its Board Manager device handle.

The expander factory API accepts an esp_io_expander_handle_t * output parameter and writes the actual esp_io_expander_handle_t into that caller-provided variable. The previous dev_gpio_expander_init() implementation allocated a separate esp_io_expander_handle_t *dev, passed dev to the factory, and correctly used *dev while Board Manager initialized the expander. However, it later published dev through *device_handle.

That made the externally visible runtime value an esp_io_expander_handle_t * instead of the documented esp_io_expander_handle_t. Because esp_board_manager_get_device_handle() exposes handles through void **, the extra indirection is not rejected by the C type system. Application code following the public contract and passing the returned value directly to esp_io_expander_*() therefore interprets the intermediate pointer allocation as an esp_io_expander_t object, which can result in invalid callback/object-field accesses.

The fix removes the unnecessary intermediate allocation:

esp_io_expander_handle_t dev = NULL;
ret = io_expander_factory_entry_t(bus_handle, dev_addr, &dev);

Board Manager now uses and publishes dev directly, so initialization, public handle retrieval, runtime use, and deinitialization all use the same handle representation. The corresponding deinit path is updated to call esp_io_expander_del() on the raw handle and no longer frees an intermediate wrapper allocation.

The existing gpio_expander test is also updated. It previously cast the returned Board Manager handle to esp_io_expander_handle_t * and dereferenced it before calling esp_io_expander_print_state(), which unintentionally matched and masked the incorrect implementation. The regression test now treats the returned value directly as esp_io_expander_handle_t, exercises direction changes, LOW/HIGH output writes, input reads, and restores the test pin to its board-configured direction/level before finishing.

No public API or configuration schema is changed. No documentation change is required because the existing documented contract already describes the returned device handle as an esp_io_expander_handle_t; this patch brings the implementation and test into alignment with that contract.

Related

No linked issue. The defect was found while integrating a Board Manager gpio_expander backed by an MCP23017 and was reproduced against the repository main branch before applying the fix.

Testing

Hardware validation was performed on an ESP32 using:

ESP-IDF:                    6.0.2
espressif/mcp23017:         0.2.0
espressif/esp_io_expander:  1.2.1
MCP23017 I2C address:       0x20 (7-bit)

The unpatched implementation completed Board Manager initialization successfully but the first application-side esp_io_expander_set_dir() using the handle returned by esp_board_manager_get_device_handle() caused a LoadStoreError.

With the patch applied, the same application-side handle usage was validated through the full lifecycle:

Board Manager initialization and MCP23017 discovery.

Initial output directions and levels.

Initial input directions and pull-ups.

Direct use of the returned esp_io_expander_handle_t.

Repeated application-side direction changes.

Repeated physical input transitions on GPA6 through a 4.7 kOhm connection to ground.

Output-mode operation on GPA6 and GPA7.

Continued expander operation after switching between input and output modes.

Full esp_board_manager_deinit() after runtime activity.

Expander deletion and I2C reference release.

I2C bus deinitialization when its reference count reached zero.

Normal return from esp_board_manager_deinit() with ESP_OK.

No panic, invalid memory access, heap corruption, or double free observed.

The updated repository test specifically regresses the handle contract by passing the value returned from esp_board_manager_get_device_handle() directly to esp_io_expander_*() operations. It does not assert a particular physical input voltage because that depends on external circuitry; it verifies that the public handle and driver operations are valid and restores the test pin afterward.